### PR TITLE
Add options for pmid extraction to take cells with numbers only

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -142,10 +142,11 @@ def extract_pmid(
     col_in: str,
     pre: str = "",
     overwrite: bool = False,
-    numbers_only: bool = False
+    numbers_only: bool = False,
 ):
     """Extracts pmid with regex taking into account pre and post. Stores it in pmid column with pubmed prefix."""
 
+    # Optinally get rid of any input value that is not a number
     if numbers_only:
         mask = df[col_in].notnull() & df[col_in].str.isdigit()
         df.loc[mask, "new_col_in"] = df.loc[mask, col_in]
@@ -156,7 +157,7 @@ def extract_pmid(
 
     regex = rf"{pre}(\d+)"
     url_prefix = "https://pubmed.ncbi.nlm.nih.gov/"
-        
+
     if ("pmid" not in list(df)) or overwrite:
         df["pmid"] = url_prefix + df[col_in].str.extract(regex)[0]
     else:

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -141,17 +141,22 @@ def extract_pmid(
     df: pd.DataFrame,
     col_in: str,
     pre: str = "",
-    post: str = "",
     overwrite: bool = False,
+    numbers_only: bool = False
 ):
     """Extracts pmid with regex taking into account pre and post. Stores it in pmid column with pubmed prefix."""
 
-    regex = rf"{pre}(\d+[^{post}]*)" if post else rf"{pre}(\d+)"
-    url_prefix = "https://pubmed.ncbi.nlm.nih.gov/"
+    if numbers_only:
+        mask = df[col_in].notnull() & df[col_in].str.isdigit()
+        df.loc[mask, "new_col_in"] = df.loc[mask, col_in]
+        df[col_in] = df["new_col_in"]
 
     # In case only numbers exist in the column, convert it to string
     df[col_in] = df[col_in].astype("string")
 
+    regex = rf"{pre}(\d+)"
+    url_prefix = "https://pubmed.ncbi.nlm.nih.gov/"
+        
     if ("pmid" not in list(df)) or overwrite:
         df["pmid"] = url_prefix + df[col_in].str.extract(regex)[0]
     else:


### PR DESCRIPTION
Enough datasets want to separate numbers only in a column from things like CN-123123123 or 123-123-123.
This gives the option to do that in utils.
Note that also the post parameter has been removed. This parameter is never useful since you automatically stop when encountering any non-digit. (Checked current scripts, no alterations needed)