### PR TITLE
Fix dataset keys in tests for correct author indexing

### DIFF
--- a/tests/test_datasets_toml.py
+++ b/tests/test_datasets_toml.py
@@ -22,9 +22,9 @@ def test_dataset_keys():
         if dataset["key"] in skip_checks:
             continue
         if dataset["key"] == "Farisogullari_2023":
-            dataset["key"] = "Farisogulları_2023"
+            dataset["key"] = "Farisogulları_2023" # The last character in the surname is a Turkish ı
         if dataset["key"] == "Giesen_2021":
-            dataset["key"] = "Bakker-Jacobs_2021"
+            dataset["key"] = "Waal_2021" # The authors are indexed incorrectly in OpenAlex
 
         if dataset["key"] == "Abgaz_2023":
             work = pyalex.Works()["https://openalex.org/W4381803634"]


### PR DESCRIPTION
I think OpenAlex has changed how the authors are indexed for this record, hence our test is suddenly failing without any code changes. I fixed the edge-case handling and all should be well again.